### PR TITLE
Fixing a bug where NAs in column would cause problems with plot/summary ...

### DIFF
--- a/R/likert.R
+++ b/R/likert.R
@@ -50,8 +50,8 @@ likert <- function(items,
 	results <- data.frame()
 	if(!is.null(grouping)) {
 		results <- data.frame(
-			Group = rep(unique(grouping), each=nlevels),
-			Response = rep(1:nlevels, length(unique(grouping)))
+			Group = rep(unique(na.omit(grouping)), each=nlevels),
+			Response = rep(1:nlevels, length(unique(na.omit((grouping)))))
 			)
 		for(i in 1:ncol(items)) {
 			t <- as.data.frame(table(grouping, as.integer(items[,i])))


### PR DESCRIPTION
I had a bunch of columns with some NAs, likert would work, but it plot() and summary() would fail with the message:

```
Error in `$<-.data.frame`(`*tmp*`, "low", value = c(15.4761904761905,  : 
replacement has 10 rows, data has 5
```

It turns out that it generated an extra NA level in R/likert.R#53

```
            Group = rep(unique(grouping), each=nlevels),
        Response = rep(1:nlevels, length(unique(grouping)))
```

unique(grouping) would be equal to Male, Female, NA.

I changed it to unique(na.omit(grouping)), and it worked perfectly. Not sure if this could cause other problems though.
