### PR TITLE
Force display of entire likert scale in bar charts

### DIFF
--- a/R/plot.likert.bar.r
+++ b/R/plot.likert.bar.r
@@ -138,7 +138,7 @@ likert.bar.plot <- function(likert,
 						 aes(fill=variable), stat='identity') + 
 				geom_bar(data=results.high, aes(fill=variable), stat='identity')
 			names(cols) <- levels(results$variable)
-			p <- p + scale_fill_manual(legend, breaks=names(cols), values=cols)
+			p <- p + scale_fill_manual(legend, breaks=names(cols), values=cols, limits=names(cols))
 		} else {
 			ymin <- 0
 			p <- ggplot(results, aes(y=value, x=Group, group=variable))
@@ -146,7 +146,8 @@ likert.bar.plot <- function(likert,
 				scale_fill_manual(legend, 
 							values=cols, 
 							breaks=levels(results$variable),
-							labels=levels(results$variable))
+							labels=levels(results$variable),
+							limits=levels(results$variable))
 		}
 		if(plot.percent.low) {
 			p <- p + geom_text(data=lsum, y=ymin, aes(x=Group, 
@@ -236,13 +237,14 @@ likert.bar.plot <- function(likert,
 						 aes(fill=variable), stat='identity') + 
 				geom_bar(data=results.high, aes(fill=variable), stat='identity')
 			names(cols) <- levels(results$variable)
-			p <- p + scale_fill_manual(legend, breaks=names(cols), values=cols)
+			p <- p + scale_fill_manual(legend, breaks=names(cols), values=cols, limits=names(cols))
 		} else {
 			p <- ggplot(results, aes(y=value, x=Item, group=Item))
 			p <- p + geom_bar(stat='identity', aes(fill=variable))
 			p <- p + scale_fill_manual(legend, values=cols, 
 							  breaks=levels(results$variable), 
-							  labels=levels(results$variable))
+							  labels=levels(results$variable),
+							  limits=levels(results$variable))
 		}
 		if(plot.percent.low) {
 			p <- p + geom_text(data=lsum, y=ymin, aes(x=Item, 


### PR DESCRIPTION
Currently, if some Likert data does not have any data points for a certain value, it will be omitted from the labels.  Ideally, I think there should be an option passed in where you can specify whether or not to show all labels or to remove any that have no values.

The limits parameter via scale in ggplot2 can help with this:

http://docs.ggplot2.org/0.9.3.1/scale_manual.html

This may also need to be fixed for the other types of graphs?  Heat, etc.?
