### PR TITLE
update wrong URLs to pdf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Kim Speerschneider [kimkspeer@gmail.com](mailto:kimkspeer@gmail.com)
 
 `likert` is an R package designed to help analyzing and visualizing Likert type items. More information can be optained at http://jason.bryer.org/likert. Also, the [included demo](https://github.com/jbryer/likert/blob/master/demo/likert.R) demonstrates many of the features.
 
-Download the 2013 useR! Conference [abstract](http://github.com/jbryer/likert/useR 2013/Abstract) and [slides](http://github.com/jbryer/likert/useR 2013/Slides).
+Download the 2013 useR! Conference [abstract](https://github.com/jbryer/likert/blob/master/useR%202013/Abstract/Speerschneider.Bryer.likert.pdf?raw=true) and [slides](https://github.com/jbryer/likert/blob/master/useR%202013/Slides/Slides.pdf?raw=true).
 
 ![Reading Attitude](http://jason.bryer.org/images/likert/centeredPlot1.png)
 ![Reading Attitude with Histogram](http://jason.bryer.org/images/likert/centeredPlot2.png)


### PR DESCRIPTION
The links were broken to the useR! 2013 abstract and slides, so I've updated those to point to the pdf files.
