### PR TITLE
Amending likert.R & summary.likert.r to use with summary results

### DIFF
--- a/R/likert.R
+++ b/R/likert.R
@@ -59,11 +59,11 @@ likert <- function(items, summary,
 					  nlevels=(ncol(summary)-1),
 					  levels=names(summary[,2:ncol(summary)]))
 		} else {
-			r <- list(results=cbind(Group=grouping, summary), 
+			r <- list(results=cbind(Group=grouping, summary[,-1]), ## split Group and summary 
 					  items=NULL, 
 					  grouping=grouping, 
-					  nlevels=(ncol(summary)-1),
-					  levels=names(summary[,2:ncol(summary)]))
+					  nlevels=(ncol(summary)-2),  ## reduce nlevels
+					  levels=names(summary[,3:ncol(summary)])) ## reduce levels
 		}
 		class(r) <- 'likert'
 		return(r)

--- a/R/likert.R
+++ b/R/likert.R
@@ -59,11 +59,11 @@ likert <- function(items, summary,
 					  nlevels=(ncol(summary)-1),
 					  levels=names(summary[,2:ncol(summary)]))
 		} else {
-			r <- list(results=cbind(Group=grouping, summary[,-1]), ## split Group and summary 
+			r <- list(results=cbind(Group=grouping, summary[,-1]), 
 					  items=NULL, 
 					  grouping=grouping, 
-					  nlevels=(ncol(summary)-2),  ## reduce nlevels
-					  levels=names(summary[,3:ncol(summary)])) ## reduce levels
+					  nlevels=(ncol(summary)-2),
+					  levels=names(summary[,3:ncol(summary)]))
 		}
 		class(r) <- 'likert'
 		return(r)

--- a/R/summary.likert.r
+++ b/R/summary.likert.r
@@ -44,13 +44,13 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 			neutral <- NA
 		}
 		if(is.null(object$grouping)) {
-			lowCols <- startCol:(center + 0.5)
+			lowCols <- startCol:floor(center + 0.5) ## insert floor
 			if(length(lowCols) == 1) {
 				low <- results[,lowCols]
 			} else {
 				low <- apply(results[,lowCols], 1, sum)
 			}
-			highCols <- ((center - 0.5) + startCol):ncol(results)
+			highCols <- (floor(center)+startCol):ncol(results) ## insert floor, remove -0.5
 			if(length(highCols) == 1) {
 				high <- results[,highCols]
 			} else {
@@ -63,13 +63,13 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 								   mean=tmp[,1],
 								   sd=tmp[,2]  )
 		} else {
-			lowCols <- startCol:(center+1)
+			lowCols <- startCol:(ceiling(center) + 1) ## insert ceiling
 			if(length(lowCols) == 1) {
 				low <- results[,lowCols]
 			} else {
 				low <- apply(results[,lowCols], 1, sum)
 			}
-			highCols <- (center+startCol):ncol(results)
+			highCols <- (floor(center)+startCol):ncol(results) ## insert floor
 			if(length(highCols) == 1) {
 				high <- results[,highCols]
 			} else {

--- a/R/summary.likert.r
+++ b/R/summary.likert.r
@@ -44,13 +44,13 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 			neutral <- NA
 		}
 		if(is.null(object$grouping)) {
-			lowCols <- startCol:center
+			lowCols <- startCol:(center + 0.5)
 			if(length(lowCols) == 1) {
 				low <- results[,lowCols]
 			} else {
 				low <- apply(results[,lowCols], 1, sum)
 			}
-			highCols <- (center+startCol):ncol(results)
+			highCols <- ((center - 0.5) + startCol):ncol(results)
 			if(length(highCols) == 1) {
 				high <- results[,highCols]
 			} else {

--- a/R/summary.likert.r
+++ b/R/summary.likert.r
@@ -41,7 +41,7 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 		if(center %% 1 == 0) {
 			neutral <- results[,(center+(startCol-1))]
 		} else {
-			netural <- NA
+			neutral <- NA
 		}
 		if(is.null(object$grouping)) {
 			lowCols <- startCol:center

--- a/R/summary.likert.r
+++ b/R/summary.likert.r
@@ -83,6 +83,18 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 								   mean=tmp[,1],
 								   sd=tmp[,2]  )			
 		}
+		narows <- which(is.na(results2$low))
+		if (length(narows) > 0) {
+		    results2[narows, ]$low <- 0
+		}
+		narows <- which(is.na(results2$neutral))
+		if (length(narows) > 0) {
+		    results2[narows, ]$neutral <- 0
+		}
+		narows <- which(is.na(results2$high))
+		if (length(narows) > 0) {
+		    results2[narows, ]$high <- 0
+		}
 		return(results2)
 	} else {
 		results <- object$results

--- a/R/summary.likert.r
+++ b/R/summary.likert.r
@@ -44,13 +44,13 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 			neutral <- NA
 		}
 		if(is.null(object$grouping)) {
-			lowCols <- startCol:floor(center + 0.5) ## insert floor
+			lowCols <- startCol:floor(center + 0.5)
 			if(length(lowCols) == 1) {
 				low <- results[,lowCols]
 			} else {
 				low <- apply(results[,lowCols], 1, sum)
 			}
-			highCols <- (floor(center)+startCol):ncol(results) ## insert floor, remove -0.5
+			highCols <- (floor(center)+startCol):ncol(results)
 			if(length(highCols) == 1) {
 				high <- results[,highCols]
 			} else {
@@ -63,13 +63,13 @@ summary.likert <- function(object, center=(object$nlevels-1)/2 + 1,
 								   mean=tmp[,1],
 								   sd=tmp[,2]  )
 		} else {
-			lowCols <- startCol:(ceiling(center) + 1) ## insert ceiling
+			lowCols <- startCol:(ceiling(center) + 1)
 			if(length(lowCols) == 1) {
 				low <- results[,lowCols]
 			} else {
 				low <- apply(results[,lowCols], 1, sum)
 			}
-			highCols <- (floor(center)+startCol):ncol(results) ## insert floor
+			highCols <- (floor(center)+startCol):ncol(results)
 			if(length(highCols) == 1) {
 				high <- results[,highCols]
 			} else {


### PR DESCRIPTION
- In **likert.R**: removed first column of summary and reduced nlevels and levels by 1, when grouping is not null.
- In **summary.likert.r**: fixed typo 'netural'; inserted floor & ceiling and adjustment when center is between response values (!center %% 1 == 0); added replacement of NA with 0 when using results.
- I've checked the changes on demo cases l29 and l29g: http://rpubs.com/m_dev/likert_summary.
