### PR TITLE
Match histograms with likert barplot when using group.order to set item order

### DIFF
--- a/R/plot.histogram.R
+++ b/R/plot.histogram.R
@@ -95,6 +95,12 @@ likert.histogram.plot <- function(l,
 							  limits=c(TRUE,FALSE),
 							  labels=c(label.missing, label.completed),
 							  values=c(missing.bar.color, bar.color))
+		
+		if(!missing(group.order)){
+		  p <- p + scale_x_discrete(limits=rev(group.order),
+		                            labels=label_wrap_mod(rev(group.order), width=wrap), drop=FALSE)
+		}
+		
 	} else {
 		hist <- data.frame( )
 		for(g in unique(l$grouping)) {

--- a/R/plot.likert.bar.r
+++ b/R/plot.likert.bar.r
@@ -204,6 +204,12 @@ likert.bar.plot <- function(l,
 			order <- lsum[order(lsum$high),'Item']
 			results$Item <- factor(results$Item, levels=order)
 		}
+		
+		
+		if(!ordered & !missing(group.order)) { 
+		  results$Item <- factor(results$Item , levels = group.order)
+		}
+		
 		ymin <- 0
 		if(centered) {
 			ymin <- -100


### PR DESCRIPTION
Fixes #71 