### PR TITLE
Add the possibility of configuring the hjust for the percentages

### DIFF
--- a/R/likert.options.R
+++ b/R/likert.options.R
@@ -52,6 +52,12 @@ likert.options <- function(
 	legend.position='bottom',
 	panel.arrange='v',
 	panel.strip.color='#F0F0F0',
+
+	plot.low.hjust = 1,
+	plot.high.hjust = -.2,
+	plot.neutral.hjust = 0.5,
+
+
 	...
 ) {
 	opts <- list(
@@ -74,7 +80,11 @@ likert.options <- function(
 		legend = legend,
 		legend.position = legend.position,
 		panel.arrange = panel.arrange,
-		panel.strip.color = panel.strip.color
+		panel.strip.color = panel.strip.color,
+
+		plot.low.hjust = plot.low.hjust,
+		plot.high.hjust = plot.high.hjust,
+		plot.neutral.hjust = plot.neutral.hjust
 	)
 	
 	return(opts)

--- a/R/plot.likert.bar.r
+++ b/R/plot.likert.bar.r
@@ -4,7 +4,8 @@ utils::globalVariables(c('value','Group','variable','low','Item','high',
 						 'wrap.grouping','centered','include.center','legend',
 						 'plot.percent.low','text.size','text.color','plot.percent.high',
 						 'plot.percent.neutral','plot.percents','panel.strip.color',
-						 'panel.arrange','legend.position'))
+						 'panel.arrange','legend.position', 'plot.low.hjust',
+						 'plot.high.hjust','plot.neutral.hjust'))
 
 #' Bar Plot for Likert Items.
 #' 
@@ -139,23 +140,23 @@ likert.bar.plot <- function(l,
 		if(plot.percent.low) {
 			p <- p + geom_text(data=lsum, y=ymin, aes(x=Group, 
 	  						   label=paste0(round(low), '%'), group=Item), 
-			  				   size=text.size, hjust=1, color=text.color)
+			  				   size=text.size, hjust=plot.low.hjust, color=text.color)
 		}
 		if(plot.percent.high) {
 			p <- p + geom_text(data=lsum, aes(x=Group, y=100, 
 							   label=paste0(round(high), '%'), 
-							   group=Item), size=text.size, hjust=-.2, color=text.color)			
+							   group=Item), size=text.size, hjust=plot.high.hjust, color=text.color)			
 		}
 		if(plot.percent.neutral & l$nlevels %% 2 == 1 & include.center) {
 			if(centered) {
 				p <- p + geom_text(data=lsum, y=0, aes(x=Group, group=Item,
 							  	   label=paste0(round(neutral), '%')),
-							       size=text.size, hjust=.5, color=text.color)
+							       size=text.size, hjust=plot.neutral.hjust, color=text.color)
 			} else {
 				lsum$y <- lsum$low + (lsum$neutral/2)
 				p <- p + geom_text(data=lsum, aes(x=Group, y=y, group=Item,
 							  	   label=paste0(round(neutral), '%')),
-							       size=text.size, hjust=.5, color=text.color)				
+							       size=text.size, hjust=plot.neutral.hjust, color=text.color)				
 			}
 		}
 		if(plot.percents) {
@@ -266,25 +267,25 @@ likert.bar.plot <- function(l,
 		if(plot.percent.low) {
 			p <- p + geom_text(data=lsum, y=ymin, aes(x=Item, 
 					  			label=paste0(round(low), '%')), 
-					  			size=text.size, hjust=1, color=text.color)
+					  			size=text.size, hjust=plot.low.hjust, color=text.color)
 		}
 		if(plot.percent.high) {
 			p <- p + geom_text(data=lsum, y=100, aes(x=Item,
 				  			label=paste0(round(high), '%')), 
-				  			size=text.size, hjust=-.2, color=text.color)
+				  			size=text.size, hjust=plot.high.hjust, color=text.color)
 		}
 		if(plot.percent.neutral & l$nlevels %% 2 == 1 & include.center & !plot.percents) {
 			if(centered) {
 				p <- p +
 					geom_text(data=lsum, y=0, 
 							  aes(x=Item, label=paste0(round(neutral), '%')),
-							  size=text.size, hjust=.5, color=text.color)
+							  size=text.size, hjust=plot.neutral.hjust, color=text.color)
 			} else {
 				lsum$y <- lsum$low + (lsum$neutral/2)
 				p <- p +
 					geom_text(data=lsum,
 							  aes(x=Item, y=y, label=paste0(round(neutral), '%')),
-							  size=text.size, hjust=.5, color=text.color)				
+							  size=text.size, hjust=plot.neutral.hjust, color=text.color)				
 			}
 		}
 		if(plot.percents) {

--- a/man/likert.options.Rd
+++ b/man/likert.options.Rd
@@ -11,8 +11,9 @@ likert.options(low.color = "#D8B365", high.color = "#5AB4AC",
   text.color = "black", centered = TRUE, include.center = TRUE,
   ordered = TRUE, wrap = 50, wrap.grouping = 50, legend = "Response",
   legend.position = "bottom", panel.arrange = "v",
+  panel.strip.color = "#F0F0F0", 
   plot.low.hjust = 1, plot.high.hjust = -.2, plot.neutral.hjust = 0.5,
-  panel.strip.color = "#F0F0F0", ...)
+  ...)
 }
 \arguments{
 \item{low.color}{color for low values.}
@@ -34,12 +35,6 @@ the number of likert levels.}
 \item{plot.percent.neutral}{whether to plot netural percentages.}
 
 \item{plot.percents}{whether to label each category/bar.}
-
-\item{plot.low.hjust}{sets the hjust of the low percentages (default=1).}
-
-\item{plot.high.hjust}{sets the hjust of the high percentages (default=-.2).}
-
-\item{plot.neutral.hjust}{sets the hjust of the neutral percentages (default=0.5).}
 
 \item{text.size}{size of text attributes.}
 
@@ -67,6 +62,12 @@ Possible values are \code{v} (vertical, the default), \code{h}
 (horizontal), and \code{NULL} (auto fill horizontal and vertical)}
 
 \item{panel.strip.color}{the background color for panel labels.}
+
+\item{plot.low.hjust}{sets the hjust of the low percentages (default=1).}
+
+\item{plot.high.hjust}{sets the hjust of the high percentages (default=-.2).}
+
+\item{plot.neutral.hjust}{sets the hjust of the neutral percentages (default=0.5).}
 
 \item{...}{included for future expansion.}
 }

--- a/man/likert.options.Rd
+++ b/man/likert.options.Rd
@@ -11,6 +11,7 @@ likert.options(low.color = "#D8B365", high.color = "#5AB4AC",
   text.color = "black", centered = TRUE, include.center = TRUE,
   ordered = TRUE, wrap = 50, wrap.grouping = 50, legend = "Response",
   legend.position = "bottom", panel.arrange = "v",
+  plot.low.hjust = 1, plot.high.hjust = -.2, plot.neutral.hjust = 0.5,
   panel.strip.color = "#F0F0F0", ...)
 }
 \arguments{
@@ -33,6 +34,12 @@ the number of likert levels.}
 \item{plot.percent.neutral}{whether to plot netural percentages.}
 
 \item{plot.percents}{whether to label each category/bar.}
+
+\item{plot.low.hjust}{sets the hjust of the low percentages (default=1).}
+
+\item{plot.high.hjust}{sets the hjust of the high percentages (default=-.2).}
+
+\item{plot.neutral.hjust}{sets the hjust of the neutral percentages (default=0.5).}
 
 \item{text.size}{size of text attributes.}
 


### PR DESCRIPTION
This PR enables users to configure the `hjust` of their percentages.

This feature has been useful to me, more specifically when plotting "more vertical" likert plots. In these cases, percentages are often bad positioned. The `hjust` configuration allows me to decide where I want the percentages to appear.