### PR TITLE
Fixed compatibility issues with tibbles

### DIFF
--- a/R/likert.R
+++ b/R/likert.R
@@ -44,7 +44,8 @@ likert <- function(items, summary,
 				   grouping=NULL, 
 				   factors=NULL,
 				   importance,
-				   nlevels=length(levels(items[,1]))) {
+				   nlevels=length(levels(items[[1]]))) {
+  items <- as.data.frame(items)
 	if(!missing(summary)) { #Pre-summarized data
 		if(!is.null(grouping) & length(grouping) != nrow(summary)) {
 			stop('The length of grouping must be equal to the number of rows in summary.')


### PR DESCRIPTION
The call from line 47 did not work with tibbles, as they never subset to a vector. To minimize changes, I only changed the default value for `nlevels' and then ensured that items is a data.frame.