### PR TITLE
Clarify use of Summary

### DIFF
--- a/R/likert.R
+++ b/R/likert.R
@@ -16,9 +16,9 @@
 #' @export
 #' @param items data frame containing the likert based items. The variables
 #'        in the data frame should be factors.
-#' @param summary a pre-summarized data frame. The first column must be the
-#'        items and the remaining columns are the levels (e.g. strongly disagree,
-#'        disagree, etc).
+#' @param summary a pre-summarized data frame. The first column must named \code{Item}
+#'        and contain the items and the remaining columns are the levels (e.g. strongly
+#'        disagree, disagree, etc).
 #' @param grouping (optional) should the results be summarized by the given
 #'        grouping variable.
 #' @param factors a vector with \code{length(factors) == ncol(items)}


### PR DESCRIPTION
If the items column is not named `Item`, then you get an error when plotting the result. The error is caused by the use of `reshape2::melt(..., id.vars = "Item")` which expects the column to be named Item. This could be solved by editing the Likert code to be more adaptive but I don't know enough about R to know if that's doable. I'm assuming it was done like that for a reason.