### PR TITLE
Fix bug with center labels if bar plot is not centered (issue #107)

### DIFF
--- a/R/plot.likert.bar.r
+++ b/R/plot.likert.bar.r
@@ -315,11 +315,17 @@ likert.bar.plot <- function(l,
 							size=text.size, color=text.color)
 			}
 			lpercentneutral <- results[results$variable == center.label,]
-			if(nrow(lpercentneutral) > 0) {
+			if(nrow(lpercentneutral) > 0 & centered) {
 				p <- p + geom_text(data=lpercentneutral, 
 								   aes(x=Item, y=0, 
 								   	label=paste0(prettyNum(abs(value * 2), digits=digits, drop0trailing=drop0trailing, zero.print=zero.print), '%')),
 								   size=text.size, color=text.color)
+			}
+			if(nrow(lpercentneutral) > 0 & !centered) {
+			  p <- p + geom_text(data=lpercentpos[lpercentpos$variable == center.label,], 
+			                     aes(x=Item, y=pos, 
+			                         label=paste0(prettyNum(value, digits=digits, drop0trailing=drop0trailing, zero.print=zero.print), '%')),
+			                         size=text.size, color=text.color)
 			}
 		}
 		p <- p +


### PR DESCRIPTION
I believe this fixes the bug described in issue #107. I tested the fix with likert demo data.

As far as I can tell, the bug results from changes in d040f5b. Center label position has to be calculated differently for centered and non-centered bar plots if `plot.percents = TRUE`. Right now it works for centered plots only. After plotting all labels except center labels (https://github.com/jbryer/likert/blob/a7cb925596dd67977a15d9912e3c4783467e8c1e/R/plot.likert.bar.r#L299-L304), center labels are right now only being plotted in a modified way for centered plots.

This is my first pull request. I appreciate all feedback.

Do you plan on submitting a new version to CRAN in the near future?