### PR TITLE
Fix error with plot.likert

### DIFF
--- a/R/plot.likert.bar.r
+++ b/R/plot.likert.bar.r
@@ -21,6 +21,7 @@ utils::globalVariables(c('value','Group','variable','low','Item','high',
 #'        items or those without a neutral option). This also influences where the
 #'        color breaks from low to high.
 #' @param ... passed to \code{\link{likert.options}}
+#' @importFrom plyr ddply
 #' @export
 #' @seealso plot.likert
 #' @seealso likert.heat.plot


### PR DESCRIPTION
The function "ddply" is currently not imported so when plot.percents is set to TRUE the function will fail (unless plyr is also loaded with the package).

This one line update to the package should resolve the issue.